### PR TITLE
Patch: Fix permission error + menu actions on language change

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -395,7 +395,7 @@ class MainWindow(QMainWindow):
         """
         Restituisce il percorso del file YAML da usare per upload/compile:
         - Se esiste un salvataggio → salva lì
-        - Altrimenti crea un file temporaneo in .temp/ dentro il progetto
+        - Altrimenti crea un file temporaneo in una cartella scrivibile
         """
         yaml_text = self.yaml_editor.toPlainText()
 
@@ -405,9 +405,14 @@ class MainWindow(QMainWindow):
             self.logger.log(f"📄 File salvato su: {self.last_save_path}", "success")
             return self.last_save_path
 
-        # Se non c'è project_dir, crea comunque qualcosa nel cwd
-        base_dir = self.project_dir or os.getcwd()
-        temp_dir = os.path.join(base_dir, ".temp")
+        # Se non c'è project_dir, usa cartella sicura in APPDATA
+        if self.project_dir:
+            base_dir = self.project_dir
+            temp_dir = os.path.join(base_dir, ".temp")
+        else:
+            base_dir = os.path.join(os.environ["APPDATA"], "ESPHomeGUIeasy")
+            temp_dir = os.path.join(base_dir, "temp")
+
         os.makedirs(temp_dir, exist_ok=True)
         temp_path = os.path.join(temp_dir, "__temp_upload.yaml")
 
@@ -417,3 +422,4 @@ class MainWindow(QMainWindow):
         self.logger.log("⚠️ Progetto non salvato. Uso file temporaneo.", "warning")
         self.logger.log(f"📄 File generato: {temp_path}", "info")
         return temp_path
+

--- a/gui/menu_bar.py
+++ b/gui/menu_bar.py
@@ -92,20 +92,45 @@ class MainMenuBar(QMenuBar):
         self.about_action.triggered.connect(self.show_about_dialog)
 
     def update_labels(self):
-        # Elimina tutti i menu e ricrea da zero
+    # Elimina tutti i menu e ricrea da zero
         self.clear()
+
+        parent = self.parent()
 
         # FILE MENU
         self.file_menu = self.addMenu(Translator.tr("menu_file"))
+
         self.new_action = QAction(Translator.tr("new_project"), self)
+        self.new_action.setShortcut("Ctrl+N")
+        self.new_action.triggered.connect(parent.nuovo_progetto)
+
         self.open_action = QAction(Translator.tr("open_project"), self)
+        self.open_action.setShortcut("Ctrl+O")
+        self.open_action.triggered.connect(lambda _: parent.open_project_dialog())
+
         self.save_action = QAction(Translator.tr("save_project"), self)
+        self.save_action.setShortcut("Ctrl+S")
+        self.save_action.triggered.connect(parent.salva_progetto)
+
         self.saveas_action = QAction(Translator.tr("save_as"), self)
+        self.saveas_action.setShortcut("Ctrl+Shift+S")
+        self.saveas_action.triggered.connect(parent.salva_con_nome)
+
         self.import_action = QAction(Translator.tr("import_yaml"), self)
+        self.import_action.triggered.connect(parent.importa_yaml)
+
         self.export_action = QAction(Translator.tr("export_yaml"), self)
+        self.export_action.triggered.connect(parent.esporta_yaml)
+
         self.import_project_action = QAction(Translator.tr("import_project"), self)
+        self.import_project_action.triggered.connect(parent.import_project)
+
         self.export_project_action = QAction(Translator.tr("export_project"), self)
+        self.export_project_action.triggered.connect(parent.export_project)
+
         self.exit_action = QAction(Translator.tr("exit"), self)
+        self.exit_action.setShortcut("Ctrl+Q")
+        self.exit_action.triggered.connect(parent.close)
 
         self.file_menu.addAction(self.new_action)
         self.file_menu.addAction(self.open_action)
@@ -138,6 +163,8 @@ class MainMenuBar(QMenuBar):
         help_menu = self.addMenu("❓")
         self.about_action.setText(Translator.tr("menu_about"))
         help_menu.addAction(self.about_action)
+        self.about_action.triggered.connect(self.show_about_dialog)
+
 
 
 


### PR DESCRIPTION
- Fixed: project compilation error due to .temp folder in Program Files
- Fixed: QAction menu items not responding after changing language
- Internal: now fallback temp files go to %APPDATA% if no project is saved
