### PR TITLE
Update setup_builder.iss

### DIFF
--- a/installation_utility/setup_builder.iss
+++ b/installation_utility/setup_builder.iss
@@ -1,8 +1,8 @@
-; Script Inno Setup per ESPHomeGUIeasy v1.3.0 con collegamenti e disinstallazione
+; Script Inno Setup per ESPHomeGUIeasy v1.4.0 con collegamenti e disinstallazione
 
 [Setup]
 AppName=ESPHomeGUIeasy
-AppVersion=1.3.0
+AppVersion=1.4.0
 DefaultDirName={autopf}\ESPHomeGUIeasy
 DefaultGroupName=ESPHomeGUIeasy
 OutputBaseFilename=ESPHomeGUIeasy_Setup


### PR DESCRIPTION
Issue:

- Two references to v1.3.0 when the version is 1.4.0.

Operating System (Windows / macOS / Linux) and version

- Linux Mint 22.1 Xia (aka; Ubuntu 24.04 Nobel)

Python version (python --version)

- Python 3.12.3

ESPHome, PyQt6, ruamel.yaml versions (pip show esphome pyqt6 ruamel.yaml)

- Name: esphome - Version: 2025.5.1
- Name: PyQt6 - Version: 6.7.0
- Name: ruamel.yaml - Version: 0.18.10

Detailed description of the issue or request

- Two references to v1.3.0 when the version is 1.4.0.