### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ You can safely click **"More info → Run anyway"** when prompted by SmartScreen
 #### 2. Clone the repository
 ```bash
 git clone https://github.com/TheWhiteWolf1985/ESPHomeGuiEasy.git
-cd esphomeGuieasy
+cd ESPHomeGuiEasy
 ```
 
 #### 3. Create a virtual environment

--- a/core/translator.py
+++ b/core/translator.py
@@ -7,7 +7,7 @@ class Translator:
     _translations = {}
     _fallback = {}
     _lang_code = "en"
-    _language_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../Language")
+    _language_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../language")
 
     @classmethod
     def load_language(cls, lang_code):

--- a/installation_utility/setup_builder.iss
+++ b/installation_utility/setup_builder.iss
@@ -1,8 +1,8 @@
-; Script Inno Setup per ESPHomeGUIeasy v1.3.0 con collegamenti e disinstallazione
+; Script Inno Setup per ESPHomeGUIeasy v1.4.0 con collegamenti e disinstallazione
 
 [Setup]
 AppName=ESPHomeGUIeasy
-AppVersion=1.3.0
+AppVersion=1.4.0
 DefaultDirName={autopf}\ESPHomeGUIeasy
 DefaultGroupName=ESPHomeGUIeasy
 OutputBaseFilename=ESPHomeGUIeasy_Setup


### PR DESCRIPTION
Issue:

- After the git clone command under installing from source, the cd command doesn't honor Linux's case sensitive directory names.  The command should be:

`cd ESPHomeGuiEasy`

Operating System (Windows / macOS / Linux) and version

- Linux Mint 22.1 Xia (aka; Ubuntu 24.04 Nobel)

Python version (python --version)

- Python 3.12.3

ESPHome, PyQt6, ruamel.yaml versions (pip show esphome pyqt6 ruamel.yaml)

- Name: esphome - Version: 2025.5.1
- Name: PyQt6 - Version: 6.7.0
- Name: ruamel.yaml - Version: 0.18.10

Detailed description of the issue or request:

- In the README.md file under the section named "Option 2: Running from source" there is a step where the repository is cloned.  The change directory (cd) command following the git clone does not honor Linux's mixed case directories:
 
 `git clone https://github.com/TheWhiteWolf1985/ESPHomeGuiEasy.git`
`cd esphomeGuieasy`
 
 It should be:
 `cd ESPHomeGuiEasy`