### PR TITLE
Update translator.py

### DIFF
--- a/core/translator.py
+++ b/core/translator.py
@@ -7,7 +7,7 @@ class Translator:
     _translations = {}
     _fallback = {}
     _lang_code = "en"
-    _language_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../Language")
+    _language_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../language")
 
     @classmethod
     def load_language(cls, lang_code):


### PR DESCRIPTION
Issue:

- Not honoring Linux's case sensitive directory names, while the language directory is named "language" the core/translator.py attempts to use a directory named "Language" which causes a failure when reading in the translation files.
- Change this:     _language_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../Language")
-  To this:     _language_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../language")

Operating System (Windows / macOS / Linux) and version

- Linux Mint 22.1 Xia (aka; Ubuntu 24.04 Nobel)

Python version (python --version)

- Python 3.12.3

ESPHome, PyQt6, ruamel.yaml versions (pip show esphome pyqt6 ruamel.yaml)

- Name: esphome - Version: 2025.5.1
- Name: PyQt6 - Version: 6.7.0
- Name: ruamel.yaml - Version: 0.18.10

Detailed description of the issue or request:
```
[2025-07-21 17:02:27] INFO [log_handler:118] - Avvio main.py
[2025-07-21 17:02:27] DEBUG [log_handler:117] - [DEBUG] Creo LanguageSelectionDialog
[2025-07-21 17:02:27] DEBUG [log_handler:117] - [DEBUG] Apro exec() sul dialog
[2025-07-21 17:02:30] DEBUG [log_handler:117] - [DEBUG] Risultato exec: 1
[2025-07-21 17:02:30] DEBUG [log_handler:117] - [DEBUG] Lingua selezionata: en
[2025-07-21 17:02:30] DEBUG [log_handler:117] - set_setting('language', 'en') chiamato da:
  File "/home/oquinn/Documents/ESPHomeGuiEasy/./main.py", line 111, in <module>
    main()
  File "/home/oquinn/Documents/ESPHomeGuiEasy/./main.py", line 80, in main
    set_setting("language", language)
  File "/home/oquinn/Documents/ESPHomeGuiEasy/./core/settings_db.py", line 45, in set_setting
    logger.debug(f"set_setting('language', '{value}') chiamato da:\n{''.join(traceback.format_stack(limit=5))}")

[2025-07-21 17:02:30] ERROR [log_handler:115] - Errore imprevisto in main()
Traceback (most recent call last):
  File "/home/oquinn/Documents/ESPHomeGuiEasy/./main.py", line 81, in main
    Translator.load_language(language.strip().lower())
  File "/home/oquinn/Documents/ESPHomeGuiEasy/./core/translator.py", line 19, in load_language
    with open(os.path.join(cls._language_dir, "en.json"), encoding="utf-8") as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/oquinn/Documents/ESPHomeGuiEasy/core/../Language/en.json'

[2025-07-21 17:02:30] ERROR [log_handler:115] - UNCAUGHT EXCEPTION
NoneType: None
```