### PR TITLE
Update GUIconfig.py MacOS option

### DIFF
--- a/config/GUIconfig.py
+++ b/config/GUIconfig.py
@@ -36,7 +36,7 @@ if platform.system() == 'Windows':
         os.makedirs(LOG_DIR, exist_ok=True)
         LOG_PATH = LOG_DIR / "log.txt"
         MODULE_SCHEMA_PATH = str(Path(__file__).parent.parent / "config" / "modules_schema.json")
-elif platform.system() == 'MacOs' :
+elif platform.system() == 'Darwin' :
     class MacOSConfig:
         COMMUNITY_LOCAL_FOLDER = str(Path.home() / "Documents" / "ESPHomeGUIeasy" / "community_projects")
         DEFAULT_PROJECT_DIR = Path.home() / "Documents" / "ESPHomeGUIeasy" / "user_projects"


### PR DESCRIPTION
Changing to 'Darwin' allowed me to successfully run ESPHomeGuiEasy on MacOS.

<img width="1612" height="1040" alt="image" src="https://github.com/user-attachments/assets/d1d1d284-02ea-433c-8f41-f1eebf98f377" />
